### PR TITLE
Fix module cannot find files in home directory.

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -231,7 +231,8 @@ def abort(msg, m):
 
 def finish(tree, xpath, m, changed=False, msg="", hitcount=0):
     if changed:
-        tree.write(m.params['file'], xml_declaration=True, encoding='UTF-8')
+        xml_file = os.path.expanduser(m.params['file'])
+        tree.write(xml_file, xml_declaration=True, encoding='UTF-8')
     m.exit_json(changed=changed,actions={"xpath": xpath, "ensure": m.params['ensure']}, msg=msg, count=hitcount)
 
 def main():
@@ -257,7 +258,7 @@ def main():
         ]
     )
 
-    xml_file = module.params['file']
+    xml_file = os.path.expanduser(module.params['file'])
     xml_string = module.params['xmlstring']
     xpath = module.params['xpath']
     ensure = module.params['ensure']


### PR DESCRIPTION
The Ansible core file modules expand the file path on processing file path arguments. This brings the module in line with expected behavior of other modules.